### PR TITLE
Update code-insiders-bin debian package data format

### DIFF
--- a/packages/code-insiders-bin/.SRCINFO
+++ b/packages/code-insiders-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = code-insiders-bin
 	pkgdesc = Code editing. Redefined.
-	pkgver = 1.91.0_1718000210
+	pkgver = 1.94.0_1726207772
 	pkgrel = 1
 	url = https://code.visualstudio.com/insiders/
 	arch = x86_64
@@ -18,7 +18,7 @@ pkgbase = code-insiders-bin
 	optdepends = glib2: Needed for move to trash functionality
 	optdepends = libdbusmenu-glib: Needed for KDE global menu
 	conflicts = visual-studio-code-insiders-bin
-	source = code-insiders_1.91.0_1718000210.deb::https://code.visualstudio.com/sha/download?build=insider&os=linux-deb-x64
+	source = code-insiders_1.94.0_1726207772.deb::https://code.visualstudio.com/sha/download?build=insider&os=linux-deb-x64
 	sha256sums = SKIP
 
 pkgname = code-insiders-bin

--- a/packages/code-insiders-bin/PKGBUILD
+++ b/packages/code-insiders-bin/PKGBUILD
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2034 disable=SC2148 disable=SC2154 disable=SC2001
 _pkgname=code-insiders
 pkgname="$_pkgname-bin"
-pkgver=1.94.0_1725948477
+pkgver=1.94.0_1726207772
 pkgrel=1
 pkgdesc="Code editing. Redefined."
 arch=('x86_64')
@@ -17,7 +17,7 @@ _download_url="https://code.visualstudio.com/sha/download?build=insider&os=linux
 
 pkgver_check() {
   IFS='/' read -ra URL <<<"$(curl -ILs -w "%{url_effective}" -o /dev/null "$_download_url")"
-  sed -e "s/${_pkgname}_\(.*\)_amd64.deb/\1/" -e 's/-/_/' <<< "${URL[7]}"
+  sed -e "s/${_pkgname}_\(.*\)_amd64.deb/\1/" -e 's/-/_/' <<<"${URL[7]}"
 }
 _pkgver=$(pkgver_check)
 pkgver() {

--- a/packages/code-insiders-bin/PKGBUILD
+++ b/packages/code-insiders-bin/PKGBUILD
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2034 disable=SC2148 disable=SC2154 disable=SC2001
 _pkgname=code-insiders
 pkgname="$_pkgname-bin"
-pkgver=1.91.0_1718000210
+pkgver=1.94.0_1725948477
 pkgrel=1
 pkgdesc="Code editing. Redefined."
 arch=('x86_64')
@@ -28,7 +28,7 @@ source=("${_pkgname}_${_pkgver}.deb::$_download_url")
 sha256sums=('SKIP')
 
 package() {
-  bsdtar -xf data.tar.xz -C "$pkgdir/"
+  bsdtar -xf data.tar.zst -C "$pkgdir/"
 
   replacement="s|\(Exec=[^%]*\)\(%.*\)|\1--no-sandbox \2|"
   sed -i "$replacement" "$pkgdir/usr/share/applications/$_pkgname.desktop"


### PR DESCRIPTION
Debian package is no longer shipped with data.tar.xz. It's in zstd format now.